### PR TITLE
Adding PT Language to Locale options

### DIFF
--- a/src/components/datepicker/locale/index.ts
+++ b/src/components/datepicker/locale/index.ts
@@ -227,6 +227,41 @@ const nl = (): any => {
   };
 };
 
+const pt = (): any => {
+  const langName = 'Português';
+  const monthFullName = [
+    'Janeiro',
+    'Fevereiro',
+    'Março',
+    'Abril',
+    'Maio',
+    'Junho',
+    'Julho',
+    'Agosto',
+    'Setembro',
+    'Outubro',
+    'Novembro',
+    'Dezembro',
+  ];
+  const shortName = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
+  const days = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sab'];
+  const daysNames = ['Domingo', 'Segunda-Feira', 'Terça-Feira', 'Quarta-Feira', 'Quinta-Feira', 'Sexta-Feira', 'Sábado'];
+  const rtl = false;
+  const ymd = false;
+  const yearSuffix = '';
+  return {
+    months: monthFullName,
+    monthsAbbr: shortName,
+    days,
+    language: langName,
+    yearSuffix,
+    ymd,
+    rtl,
+    langName,
+    daysNames,
+  };
+};
+
 export const data = {
   af: af(),
   hi: hi(),
@@ -235,4 +270,5 @@ export const data = {
   en: en(),
   fr: fr(),
   nl: nl(),
+  pt: pt(),
 };


### PR DESCRIPTION
This commit will add the support for PT (Portuguese) language to the locale options consumed by the datepicker component.